### PR TITLE
unit-test-coverage for all files

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,5 @@
  * UI Test (Galen or alternative?)
  * Split libs in own modules
  * Update package.json
- * Code Coverage (nyc - coverage report is not correct currently)
  * Benchmark (benchmark.js chuhai, ...)
  * Latest Node.js - https://github.com/xolvio/chimp/pull/393

--- a/honeycomb-template/.babelrc
+++ b/honeycomb-template/.babelrc
@@ -1,13 +1,12 @@
 {
   "presets": ["es2015", "react"],
   "plugins": [
-      "transform-runtime",
-      "transform-class-properties",
-      "transform-object-rest-spread"
+    "transform-runtime",
+    "transform-class-properties",
+    "transform-object-rest-spread"
   ],
   "env": {
     "test": {
-      "plugins": ["__coverage__"],
       "sourceMaps": "inline"
     }
   }

--- a/honeycomb-template/package.json
+++ b/honeycomb-template/package.json
@@ -10,9 +10,10 @@
     "start:production": "pm2 start .config/pm2.production.json",
     "test": "npm run test:integration && npm run test:unit",
     "test:integration": "chimp .config/chimp.js",
-    "test:unit": "ava",
-    "test:unit:watch": "npm run test:unit -- --watch",
-    "test:unit:coverage": "cross-env BABEL_ENV=test nyc --all npm run test:unit && nyc report",
+    "test:unit": "nyc --all --require=babel-core/register --include=src/ ava",
+    "test:unit:watch": "ava -- --watch",
+    "test:unit:report": "nyc report --reporter=lcov",
+
     "build": "webpack --config .config/webpack.config.js --env.dev",
     "build:production": "webpack --config .config/webpack.config.js --env.prod -p",
     "build:watch": "webpack-dev-server --config .config/webpack.config.js --env.dev --content-base dist/"
@@ -39,9 +40,7 @@
   "devDependencies": {
     "ava": "^0.15.2",
     "babel-loader": "^6.2.4",
-    "babel-plugin-__coverage__": "^11.0.0",
     "chimp": "^0.35.0",
-    "cross-env": "^1.0.8",
     "css-loader": "^0.23.1",
     "enzyme": "^2.3.0",
     "eslint": "^2.13.1",
@@ -66,15 +65,7 @@
       "babel-core/register",
       "./.config/browsersetup.js"
     ],
+    "verbose": "true",
     "babel": "inherit"
-  },
-  "nyc": {
-    "include": ["src/**/*.(js|jsx)"],
-    "extension": ["jsx"],
-    "reporter": ["lcov", "text"],
-    "require": ["babel-core/register"],
-    "sourceMap": "inline",
-    "instrument": false,
-    "cache": false
   }
 }


### PR DESCRIPTION
fixed coverage usage with nyc, now it shows the right coverage ov each file.

documentation in ava was better, than the one in nyc 😢 