### PR TITLE
remove test:integration from npm test

### DIFF
--- a/generator-honeycomb/app/templates/_package.json
+++ b/generator-honeycomb/app/templates/_package.json
@@ -18,7 +18,7 @@
     "start": "npm run start:development",
     "start:development": "pm2-dev start .config/pm2.development.json",
     "start:production": "pm2 start .config/pm2.production.json",
-    "test": "npm run lint && npm run test:integration && npm run test:unit",
+    "test": "npm run lint && npm run test:unit",
     "test:integration": "chimp .config/chimp.js",
     "test:unit": "jest",
     "test:unit:watch": "jest --watch"


### PR DESCRIPTION
i often had the problem, that i can not commit, because of the integration tests and a not running server.

i think we should run the test:integration manually instead of automatic with npm test.
we can also discuss about this tomorrow ^^