### PR TITLE
make generated services private to npm

### DIFF
--- a/packages/generator-honeycomb/app/templates/_package.json
+++ b/packages/generator-honeycomb/app/templates/_package.json
@@ -3,6 +3,7 @@
   "version": "<%= packageVersion %>",
   "description": "<%= packageDescription %>",
   "main": "src/server/server.js",
+  "private": true,
   "scripts": {
     <%_ if (includeReact) { _%>
     "build": "npm run build:babel && npm run build:webpack",


### PR DESCRIPTION
the generated services should be private in the package.json, ´cause we will never release them to npm / installation via npm wouldn´t be very usefull