### PR TITLE
Cleanup tests

### DIFF
--- a/packages/honeycomb-assets/__tests__/server/index.test.js
+++ b/packages/honeycomb-assets/__tests__/server/index.test.js
@@ -70,7 +70,7 @@ describe('honeycomb-assets', () => {
           path: '/{param*}',
           handler: {
             directory: {
-              path: path.resolve(__dirname, '..', '..', 'src', 'client'),
+              path: path.resolve('src', 'client'),
             },
           },
         });

--- a/packages/honeycomb-layout/__tests__/src/index.test.js
+++ b/packages/honeycomb-layout/__tests__/src/index.test.js
@@ -1,4 +1,3 @@
-jest.mock('path');
 jest.mock('honeycomb-server');
 
 const path = require('path');
@@ -7,17 +6,12 @@ const honeycombServer = require('honeycomb-server');
 describe('honeycomb-layout', () => {
   beforeEach(() => {
     honeycombServer.start = jest.fn();
-    path.join.mockImplementation((...args) => {
-      args.shift();
-      return args.join('/');
-    });
     require('../../src/index'); // eslint-disable-line global-require
   });
 
   afterEach(() => {
     jest.resetAllMocks();
   });
-
 
   it('should called "honeycombServer.start()" with options', () => {
     expect(honeycombServer.start).toBeCalledWith({
@@ -28,7 +22,7 @@ describe('honeycomb-layout', () => {
         {
           module: 'hapi-tailor-middleware',
           options: {
-            templatesPath: '../templates',
+            templatesPath: path.resolve('templates'),
           },
         },
       ],

--- a/packages/honeycomb-server/__tests__/lib/index.test.js
+++ b/packages/honeycomb-server/__tests__/lib/index.test.js
@@ -65,24 +65,22 @@ describe('honeycomb-server', () => {
       expect(honeycombServer.start().constructor.name).toBe('Promise');
     });
 
-    // eslint-disable-next-line arrow-body-style
-    it('should be return the server', () => {
-      return honeycombServer.start()
+    it('should be return the server', () => (
+      honeycombServer.start()
         .then((serverInstance) => {
           expect(server).toEqual(serverInstance);
-        });
-    });
+        })
+    ));
 
-    // eslint-disable-next-line arrow-body-style
-    it('should have been called console.info()', () => {
-      return honeycombServer.start()
+    it('should have been called console.info()', () => (
+      honeycombServer.start()
         .then(() => {
           // eslint-disable-next-line no-console
           expect(console.info).toBeCalledWith(
             'Server running at:', 'http://honeycomb.example.com:3000'
           );
-        });
-    });
+        })
+    ));
   });
 
   describe('connection', () => {
@@ -154,19 +152,17 @@ describe('honeycomb-server', () => {
       });
     });
 
-    // eslint-disable-next-line arrow-body-style
-    it('should have been called console.error()', () => {
-      return myServer.then(() => {
+    it('should have been called console.error()', () => (
+      myServer.then(() => {
         // eslint-disable-next-line no-console
-        expect(console.error).toBeCalledWith('There was an error starting the server');
-      });
-    });
+        expect(console.error).toBeCalledWith(
+          'There was an error starting the server'
+        );
+      })
+    ));
 
-    // eslint-disable-next-line arrow-body-style
-    it('should have been called server.stop()', () => {
-      return myServer.then(() => {
-        expect(server.stop).toHaveBeenCalled();
-      });
-    });
+    it('should have been called server.stop()', () => (
+      myServer.then(() => expect(server.stop).toHaveBeenCalled())
+    ));
   });
 });


### PR DESCRIPTION
Remove unnecessary `return` statements, `new lines`, `mocks`, ...