### PR TITLE
[honeycomb-status-middleware] Wrap hapijs-status-monitor into a separate module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ cache:
     - packages/honeycomb-logging-middleware/node_modules
     - packages/honeycomb-registry-client/node_modules
     - packages/honeycomb-server/node_modules
+    - packages/honeycomb-status-middleware/node_modules
     - packages/generator-honeycomb/node_modules
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 | [honeycomb-layout](./packages/honeycomb-layout) | Layout service for Honeycomb |
 | [honeycomb-logging-middleware](./packages/honeycomb-logging-middleware) | Logging middleware for Honeycomb |
 | [honeycomb-registry-client](./packages/honeycomb-registry-client) | Service registry client for Honeycomb |
+| [honeycomb-status-middleware](./packages/honeycomb-status-middleware) | Status endpoint for Honeycomb |
 | [honeycomb-server](./packages/honeycomb-server) | Server for Honeycomb |
 
 ## Development

--- a/packages/generator-honeycomb/app/templates/.config/_server.js
+++ b/packages/generator-honeycomb/app/templates/.config/_server.js
@@ -50,24 +50,11 @@ const defaultConfig = {
     },
   ],
   plugins: [
-    {
-      module: 'vision',
-    },
-    {
-      module: 'inert',
-    },
-    {
-      module: 'honeycomb-logging-middleware',
-    },
-    {
-      module: 'hapijs-status-monitor',
-      options: {
-        title: 'Status',
-      },
-    },
-    {
-      module: 'honeycomb-health-middleware',
-    },
+    { module: 'vision' },
+    { module: 'inert' },
+    { module: 'honeycomb-logging-middleware' },
+    { module: 'honeycomb-health-middleware' },
+    { module: 'honeycomb-status-middleware' },
     {
       module: 'honeycomb-info-middleware',
       options: {

--- a/packages/generator-honeycomb/app/templates/_package.json
+++ b/packages/generator-honeycomb/app/templates/_package.json
@@ -41,7 +41,6 @@
     "hapi-react-views": "^9.2.1",
     <%_ } _%>
     "hapi-router": "^3.5.0",
-    "hapijs-status-monitor": "^0.5.0",
     <%_ if (includeHandlebars) { _%>
     "handlebars": "^4.0.6",
     <%_ } _%>
@@ -51,6 +50,7 @@
     "honeycomb-logging-middleware": "^1.0.0",
     "honeycomb-registry-client": "^1.0.0",
     "honeycomb-server": "^1.0.0",
+    "honeycomb-status-middleware": "^1.0.0",
     "inert": "^4.1.0",
     <%_ if (includeReact) { _%>
     "react": "^15.4.2",

--- a/packages/honeycomb-assets/__tests__/server/index.test.js
+++ b/packages/honeycomb-assets/__tests__/server/index.test.js
@@ -34,27 +34,13 @@ describe('honeycomb-assets', () => {
 
     expect(honeycombServer.start).toBeCalledWith({
       plugins: [
-        {
-          module: 'inert',
-        },
-        {
-          module: 'honeycomb-logging-middleware',
-        },
-        {
-          module: 'honeycomb-health-middleware',
-        },
+        { module: 'inert' },
+        { module: 'honeycomb-logging-middleware' },
+        { module: 'honeycomb-health-middleware' },
+        { module: 'honeycomb-status-middleware' },
         {
           module: 'honeycomb-info-middleware',
-          options: {
-            pkg,
-            process,
-          },
-        },
-        {
-          module: 'hapijs-status-monitor',
-          options: {
-            title: 'Status',
-          },
+          options: { pkg, process },
         },
       ],
     });

--- a/packages/honeycomb-assets/package.json
+++ b/packages/honeycomb-assets/package.json
@@ -24,12 +24,12 @@
   "dependencies": {
     "babel-runtime": "^6.22.0",
     "cross-env": "^3.1.4",
-    "hapijs-status-monitor": "^0.5.0",
     "honeycomb-health-middleware": "^1.0.0",
     "honeycomb-info-middleware": "^1.0.0",
     "honeycomb-logging-middleware": "^1.0.0",
     "honeycomb-registry-client": "^1.0.0",
     "honeycomb-server": "^1.0.0",
+    "honeycomb-status-middleware": "^1.0.0",
     "inert": "^4.1.0"
   },
   "devDependencies": {

--- a/packages/honeycomb-assets/src/server/index.js
+++ b/packages/honeycomb-assets/src/server/index.js
@@ -8,13 +8,10 @@ honeycombServer
       { module: 'inert' },
       { module: 'honeycomb-logging-middleware' },
       { module: 'honeycomb-health-middleware' },
+      { module: 'honeycomb-status-middleware' },
       {
         module: 'honeycomb-info-middleware',
         options: { pkg, process },
-      },
-      {
-        module: 'hapijs-status-monitor',
-        options: { title: 'Status' },
       },
     ],
   })

--- a/packages/honeycomb-status-middleware/.eslintignore
+++ b/packages/honeycomb-status-middleware/.eslintignore
@@ -1,0 +1,1 @@
+/coverage/**

--- a/packages/honeycomb-status-middleware/.eslintrc.yml
+++ b/packages/honeycomb-status-middleware/.eslintrc.yml
@@ -1,0 +1,2 @@
+extends:
+  honeycomb/base

--- a/packages/honeycomb-status-middleware/README.md
+++ b/packages/honeycomb-status-middleware/README.md
@@ -1,0 +1,51 @@
+# honeycomb-status-middleware
+
+> Status endpoint for Honeycomb using [hapijs-status-monitor](https://github.com/ziyasal/hapijs-status-monitor)
+
+## Installation
+
+```bash
+npm install --save honeycomb-status-middleware
+```
+
+## Endpoint
+
+`/admin/status`
+
+## Usage
+
+```javascript
+server.register([{
+  register: require('honeycomb-status-middleware'),
+}], (err) => {
+  if (err) {
+    throw err;
+  }
+});
+```
+
+## Configuration
+
+### `options: {}`
+
+An object with `title` (string).
+
+#### Default
+
+```javascript
+{
+  title: 'Status',
+}
+```
+
+#### Example
+
+```javascript
+{
+  title: 'My Status Monitor',
+}
+```
+
+## License
+
+Copyright (c) 2017 Daniel Bayerlein. See [LICENSE](../../LICENSE.md) for details.

--- a/packages/honeycomb-status-middleware/__tests__/lib/index.test.js
+++ b/packages/honeycomb-status-middleware/__tests__/lib/index.test.js
@@ -1,0 +1,47 @@
+jest.mock('hapijs-status-monitor');
+
+const hapijsStatusMonitorPlugin = require('hapijs-status-monitor');
+const register = require('../../lib/index').register;
+const pkg = require('../../package.json');
+
+describe('honeycomb-status-middleware', () => {
+  let server;
+  let options;
+  let next;
+  let title = 'Status';
+  const path = '/admin/status';
+
+  beforeEach(() => {
+    options = {};
+    next = jest.fn();
+    server = {
+      register: jest.fn(),
+    };
+  });
+
+  it('should have been called server.register with expected options', () => {
+    register(server, options, next);
+    expect(server.register).toHaveBeenCalledWith({
+      options: { path, title },
+      register: hapijsStatusMonitorPlugin,
+    });
+  });
+
+  it('should have been called server.register with custom title', () => {
+    title = 'My Status Monitor';
+    register(server, { title }, next);
+    expect(server.register).toHaveBeenCalledWith({
+      options: { path, title },
+      register: hapijsStatusMonitorPlugin,
+    });
+  });
+
+  it('should have been called next()', () => {
+    register(server, options, next);
+    expect(next).toBeCalled();
+  });
+
+  it('should return the package as register.attributes.pkg', () => {
+    expect(register.attributes.pkg).toBe(pkg);
+  });
+});

--- a/packages/honeycomb-status-middleware/lib/index.js
+++ b/packages/honeycomb-status-middleware/lib/index.js
@@ -1,0 +1,16 @@
+const hapijsStatusMonitor = require('hapijs-status-monitor');
+const pkg = require('../package.json');
+
+exports.register = function register(server, options, next) {
+  const title = options.title || 'Status';
+  const path = '/admin/status';
+
+  server.register({
+    register: hapijsStatusMonitor,
+    options: { title, path },
+  });
+
+  return next();
+};
+
+exports.register.attributes = { pkg };

--- a/packages/honeycomb-status-middleware/package.json
+++ b/packages/honeycomb-status-middleware/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "honeycomb-status-middleware",
+  "version": "1.0.0",
+  "description": "Status endpoint for Honeycomb",
+  "main": "lib/index.js",
+  "scripts": {
+    "lint": "eslint --format=node_modules/eslint-formatter-pretty .",
+    "test": "npm run lint && npm run test:unit",
+    "test:unit": "jest --coverage"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/danielbayerlein/honeycomb.git"
+  },
+  "keywords": [
+    "honeycomb",
+    "hapi.js",
+    "middleware",
+    "status",
+    "monitor"
+  ],
+  "author": "Daniel Bayerlein",
+  "license": "MIT",
+  "dependencies": {
+    "hapijs-status-monitor": "^0.5.0"
+  },
+  "devDependencies": {
+    "eslint": "^3.14.0",
+    "eslint-config-honeycomb": "^1.0.0",
+    "eslint-formatter-pretty": "^1.1.0",
+    "eslint-plugin-import": "^2.2.0",
+    "jest": "^18.1.0"
+  },
+  "peerDependencies": {
+    "hapi": "^16.0.0"
+  },
+  "jest": {
+    "bail": true
+  }
+}


### PR DESCRIPTION
This PR wrap `hapijs-status-monitor` into a separate module.

**Pros**

* Same endpoint for each service ➡️ `/admin/status`

**Options**
* You can customize the `title`