### PR TITLE
Cleanup Dockerfile 🐳

### DIFF
--- a/packages/generator-honeycomb/app/templates/_Dockerfile
+++ b/packages/generator-honeycomb/app/templates/_Dockerfile
@@ -1,11 +1,5 @@
 FROM node:alpine
 
-# Install Yarn
-RUN apk add --no-cache --virtual .build-deps tar curl bash gnupg \
-  && curl -o- -L https://yarnpkg.com/install.sh | bash \
-  && apk del .build-deps
-ENV PATH /root/.yarn/bin:$PATH
-
 # Create app directory
 RUN mkdir -p /code/<%= dir %>
 WORKDIR /code/<%= dir %>


### PR DESCRIPTION
Remove manual `yarn` installation, because it's now a part of `node:alpine`