### PR TITLE
Cleanup Dockerfile 🐳 (honeycomb-layout + honeycomb-assets)

### DIFF
--- a/packages/honeycomb-assets/Dockerfile
+++ b/packages/honeycomb-assets/Dockerfile
@@ -1,11 +1,5 @@
 FROM node:alpine
 
-# Install Yarn
-RUN apk add --no-cache --virtual .build-deps tar curl bash gnupg \
-  && curl -o- -L https://yarnpkg.com/install.sh | bash \
-  && apk del .build-deps
-ENV PATH /root/.yarn/bin:$PATH
-
 # Create app directory
 RUN mkdir -p /code/honeycomb-assets
 WORKDIR /code/honeycomb-assets

--- a/packages/honeycomb-layout/Dockerfile
+++ b/packages/honeycomb-layout/Dockerfile
@@ -1,11 +1,5 @@
 FROM node:alpine
 
-# Install Yarn
-RUN apk add --no-cache --virtual .build-deps tar curl bash gnupg \
-  && curl -o- -L https://yarnpkg.com/install.sh | bash \
-  && apk del .build-deps
-ENV PATH /root/.yarn/bin:$PATH
-
 # Create app directory
 RUN mkdir -p /code/honeycomb-layout
 WORKDIR /code/honeycomb-layout


### PR DESCRIPTION
Remove manual `yarn` installation, because it's now a part of `node:alpine`